### PR TITLE
fix broken large image resource

### DIFF
--- a/lcp-large-image/index.html
+++ b/lcp-large-image/index.html
@@ -19,7 +19,7 @@
       <img
         width="500"
         height="500"
-        src="https://via.placeholder.com/3000.jpg"
+        src="https://via.placeholder.com/2000.jpg"
         alt="A larger image"
       />
     </div>


### PR DESCRIPTION
stumbled upon https://via.placeholder.com/3000.jpg being broken, swapping it with a working https://via.placeholder.com/2000.jpg