### PR TITLE
add new story with nested scheduler.postTask() calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 <li><a href="nested-interactions/index.html">nested-interactions</a></li>
 <li><a href="node-fib-app/index.html">node-fib-app</a></li>
 <li><a href="react-hello-world/index.html">react-hello-world</a></li>
+<li><a href="scheduler/index.html">scheduler</a></li>
 <li><a href="scheduler-posttask/index.html">scheduler-posttask</a></li>
 <li><a href="soft-navigations/index.html">soft-navigations</a></li>
 <li><a href="source-map/index.html">source-map</a></li>

--- a/scheduler/app.js
+++ b/scheduler/app.js
@@ -1,0 +1,52 @@
+function spin(multiplier) {
+  // Just wait a while, avoiding annoying flame chart from perf.now() calls.
+  for (let i = 0; i < 2_000_000 * multiplier; i++) {}
+}
+
+/*
+ * ┌┐      ┌───────────┌──────┐
+ * S1─────►R1          R2     │
+ * └┘      └──┌┐───┌┐──└▲────┌┐
+ *            S2┐  S3-──┼───►C3
+ *            └┘│  └┘   │    └┘
+ *              └───────┘
+ * S - Schedule
+ * R - Run
+ * C - Cancel
+ */
+async function taskWithSubTasks() {
+  spin(100);
+
+  const backgroundController = new TaskController();
+  const backgroundSubtask = scheduler.postTask(() => {
+    spin(500);
+  }, {priority: 'background', signal: backgroundController.signal});
+
+  spin(50);
+
+  // Cancel background task in higher-priority task.
+  const userBlockingSubTask = scheduler.postTask(() => {
+    spin(100);
+    backgroundController.abort('cancel background work')
+  }, {priority: 'user-blocking'});
+
+  spin(100);
+  return Promise.allSettled([backgroundSubtask, userBlockingSubTask]);
+}
+
+/*
+ * ┌┐     ┌────────────┐
+ * S┼────►R            │
+ * └┘     └───────────┌┐
+ * └─────────────────►C│
+ *                    └┘
+*/
+const selfCancellingController = new TaskController();
+async function selfCancellingTask() {
+  spin(100);
+  // RunPostTaskCallback starts but calls its own cancellation.
+  selfCancellingController.abort('just get rid of me');
+}
+
+await scheduler.postTask(taskWithSubTasks, {delay: 200});
+await scheduler.postTask(selfCancellingTask, {delay: 100, signal: selfCancellingController.signal});

--- a/scheduler/index.html
+++ b/scheduler/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>nested scheduler.postTask()</title>
+    <style></style>
+  </head>
+  <body>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
To support https://crrev.com/c/5952311, an uglier and more complicated scheduler.postTask() example. I'm not sure where [`scheduler-posttask/`](https://github.com/ChromeDevTools/performance-stories/tree/main/scheduler-posttask) is used, so I didn't want to modify that one, but now this is in a pretty generic directory name. Open to changing it to whatever :)